### PR TITLE
v0.4.1: fix agent log unknown + enable no-explicit-any in tests

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -149,7 +149,6 @@ export default tseslint.config(
     plugins: { vitest, "import-x": importX },
     rules: {
       ...vitest.configs.recommended.rules,
-      "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-unsafe-assignment": "off",
       "@typescript-eslint/no-unsafe-member-access": "off",
       "@typescript-eslint/no-unsafe-call": "off",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-auto-fallback",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Advanced fallback plugin for OpenCode agents — model switching, retry with backoff, and context overflow handling",
   "type": "module",
   "main": "src/index.ts",

--- a/src/hooks/events.ts
+++ b/src/hooks/events.ts
@@ -489,7 +489,7 @@ async function handleSessionStatus(
     await logger.info(`Session status: ${statusType}`, {
       sessionID: props.sessionID,
       phase: phase ?? "none",
-      agent: agent ?? "unknown",
+      ...(agent ? { agent } : {}),
     });
   }
 


### PR DESCRIPTION
## Summary

- **fix**: Omit agent field from `session.status` logs when unknown, instead of logging a misleading `"unknown"` value (cosmetic)
- **chore**: Enable `@typescript-eslint/no-explicit-any` rule in test files

## Changes

- `src/hooks/events.ts`: `agent ?? "unknown"` → `...(agent ? { agent } : {})`
- `eslint.config.ts`: Remove `"no-explicit-any": "off"` override from test file config
- `package.json`: 0.4.0 → 0.4.1